### PR TITLE
Fix createImageFromParams to return raw image or url using a custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ sudo xattr -rd com.apple.quarantine /Applications/Chromium.app # Remove quaranti
 
 ### On Debian/Ubuntu
 
+For Ubuntu 22.04+ (Note: you'll need to update the environment variable of `CHROME_PATH` to `chomium-browser`)
+
+```bash
+sudo add-apt-repository ppa:savoury1/ffmpeg4
+sudo add-apt-repository ppa:savoury1/chromium
+sudo apt-get update
+sudo apt-get install chromium-browser
+```
+
+For Ubuntu everything below 22.04
+
 ```bash
 # Install chromium from PPA instead of snap, because of permission issues with snapd version
 sudo add-apt-repository ppa:saiarcot895/chromium-dev -y

--- a/src/OgImage.php
+++ b/src/OgImage.php
@@ -57,7 +57,7 @@ class OgImage
 
     public function getStorageImageFileExists(string $signature): bool
     {
-        if(config('og-image.debug') === true) {
+        if (config('og-image.debug') === true) {
             return false;
         }
 
@@ -69,7 +69,9 @@ class OgImage
     {
         return $this->getStorageDisk()
             ->get($this->getStorageImageFilePath($signature));
-    }    public function getStorageViewFileName(string $signature): string
+    }
+
+    public function getStorageViewFileName(string $signature): string
     {
         return $signature.'.blade.php';
     }
@@ -132,19 +134,29 @@ class OgImage
         return $parameters['signature'];
     }
 
-    public function createImageFromParams(array $parameters): ?string
+    public function createImageFromParams(array $parameters, ?string $template = null, bool $returnImage = false): ?string
     {
         $signature = $this->getSignature($parameters);
 
         if (! OgImage::getStorageImageFileExists($signature)) {
-            $html = View::make('og-image::template', $parameters)
-                ->render();
+            if (! empty($template) && View::exists($template)) {
+                $html = View::make($template, $parameters)
+                    ->render();
+            } else {
+                $html = View::make('og-image::template', $parameters)
+                    ->render();
+            }
 
             OgImage::saveImage($html, $signature);
         }
 
-        return Storage::disk(config('og-image.storage.disk'))
-            ->url(OgImage::getStorageImageFilePath($signature));
+        if (! $returnImage) {
+            return Storage::disk(config('og-image.storage.disk'))
+                ->url(OgImage::getStorageImageFilePath($signature));
+        } else {
+            return Storage::disk(config('og-image.storage.disk'))
+                ->get(OgImage::getStorageImageFilePath($signature));
+        }
     }
 
     public function saveImage(string $html, string $filename): void
@@ -196,7 +208,7 @@ class OgImage
                 ->render();
         }
 
-        if($request->route()->getName() == 'og-image.html') {
+        if ($request->route()->getName() == 'og-image.html') {
             return response($html, 200, [
                 'Content-Type' => 'text/html',
             ]);


### PR DESCRIPTION
This pull request includes updates to documentation and enhancements to the `OgImage` class to improve functionality and maintainability. The most important changes involve adding installation instructions for different Ubuntu versions in the `README.md` and extending the `createImageFromParams` method to support custom templates and return options.

Previously the method `createImageFromParams` used a custom template and returned a raw image this PR makes a change to reintroduce this support. By default `createImageFromParams` will return the url of the generated/cached image.

### Documentation Updates:

* **Added installation instructions for Ubuntu 22.04+**: Updated the `README.md` to include steps for installing Chromium on Ubuntu 22.04+ using a new PPA, along with a note to update the `CHROME_PATH` environment variable.

### Enhancements to `OgImage` Class:

* **Improved method formatting**: Fixed formatting in the `getStorageImageFileData` and `getStorageViewFileName` methods to improve code readability.
* **Extended `createImageFromParams` method**: Added support for specifying a custom template and an option to return the raw image data instead of the URL. This makes the method more versatile for different use cases.